### PR TITLE
v0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,26 @@ The `config` object accepts the following fields:
    * `replaceTargetContent`: If `false`, generated iFrame is appended to `targetElement`'s children. Otherwise, the default behaviour is to replace the content of `targetElement`.
    * `options`: Additional customisations.
        * `options.path`: Custom path to navigate to once the app is initialised e.g. starting on a specific chat.
-       * `options.contactsTappable`: if `true`, contacts are tappable and will raise a "click-on-contact" event when contacts are tapped within the app.
+       * `options.contactsTappable`: if `true`, contacts are tappable and will raise a "click-on-contact" event when contacts are tapped in chat details and on contact list.
        * `options.imagePreview`: if `false`, the in-app image preview is disabled and clicking on images will trigger downloads instead.
        * `options.pdfPreview`: if `false`, the in-app PDF preview is disabled and clicking on pdf files will trigger downloads instead.
        * `options.emitDownloads`: if `true`, `download-request` event are emitted instead downloads. This allows you to handle the download/preview logic yourself.
        * `options.emitMeetingJoin`: if `true`, `meeting-join` event are emitted instead opening meeting URLs in new window. This allows you to handle the loading of meeting URLs yourself.
-       * `options.chatListTitle`: custom title to display in the header of the Chat List.
-       * `options.chatListLogo`: URL of logo to display in the header of the Chat List. Specifying this will replace the text title with the logo image.
-       * `options.emitChatListBack`: if `true`, a back button is shown on the Chat List, which when clicked will emit a `chat-list-back` event.
        * `options.hideChatBack`: if `true`, the back button on Chat screens are hidden. This is only practical if you have used `options.path` to deeplink to a specific chat.
+       * `options.hideTopNav`: if `true`, the Tab navigation on main screens (Contacts/Chats) is hidden. Use this if you want to implement your own nav.
+       * `options.topNavLabelContacts`: custom label for "contacts" in Tab navigation on main screens (Contacts/Chats).
+       * `options.topNavLabelChats`: custom label for "chats" in Tab navigation on main screens (Contacts/Chats).
+       * `options.topNavHeading`: if specified, an extra header is added above the Tab navigation.
+       * `options.contactEmailClickable`: if `false`, email addresses in contact list will not be clickable. Otherwise, it will open default mail client.
+       * `options.contactPhoneClickable`: if `false`, phone numbers in contact list will not be clickable. Otherwise, it will open default phone client.
+       * `options.showOrgNameOnContactsPage`: if `true`, the organisation name is displayed on the Contacts page.
+       * `options.canStartChat`: if `false`, the button to start chats will be hidden.
+       * `options.startChatTitle`: custom text to use as title in the "Start Chat" dialog.
+       * `options.startChatSubmitButtonText`: custom text to use in submit button in the "Start Chat" dialog.
+       * `options.startChatTitleLabel`: custom text to use as label for chat title input in the "Start Chat" dialog.
+       * `options.startChatMessageLabel`: custom text to use as label for message input in the "Start Chat" dialog.
+       * `options.searchBackButtonLabel`: custom text to use as label for "back" button on search results.
+       * `options.searchNoResultsMessage`: custom text to use in message when no search results found.
        * `options.theme`: CSS overrides to customise the look and feel of the app
          * `options.theme.bubbleBgColour`: Background colour of chat bubble for own message
          * `options.theme.bubbleTextColour`: Text colour of chat bubble for own message
@@ -163,6 +174,18 @@ The listener receives an object with the following structure:
 }
 ```
 
+### path-change
+
+Emitted when navigation between screens happen.
+
+The listener receives an object with the following structure:
+
+```javascript
+{
+  path: string // The current path
+}
+```
+
 ### click-on-contact
 
 Emitted when `contactsTappable` feature is enabled and a user taps on a contact.
@@ -211,12 +234,6 @@ The listener receives an object with the following structure:
   meetingUuid: string // UUID of the meeting
 }
 ```
-
-### chat-list-back
-
-Emitted when `emitChatListBack` feature is enabled and a user clicks on back button on the chat list.
-
-This event has no payload.
 
 ## Functions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwil-iframe-api",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Qwil IFrame Api",
   "author": "Qwil",
   "repository": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-export const LIB_VERSION = '0.1.3';
+export const LIB_VERSION = '0.2.5';
 
 // Print simple banner on load to aid debugging and bug reporting
 console.log(`Qwil IFrame API (version ${LIB_VERSION})`);

--- a/types/qwil-iframe-api.d.ts
+++ b/types/qwil-iframe-api.d.ts
@@ -25,10 +25,24 @@ export interface QwilApiProps {
     emitDownloads?: boolean,
     emitMeetingJoin?: boolean,
 
-    chatListTitle?: string,
-    chatListLogo?: string,
-    emitChatListBack?: boolean,
-    disableChatBack?: boolean,
+    hideChatBack?: boolean,
+    hideTopNav?: boolean,
+    topNavLabelContacts?: string,
+    topNavLabelChats?: string,
+    topNavHeading?: string,
+
+    contactEmailClickable?: string,
+    contactPhoneClickable?: string,
+    showOrgNameOnContactsPage?: boolean,
+
+    canStartChat?: boolean,
+    startChatTitle?: string,
+    startChatSubmitButtonText?: string,
+    startChatTitleLabel?: string,
+    startChatMessageLabel?: string,
+
+    searchBackButtonLabel?: string,
+    searchNoResultsMessage?: string,
   };
   width?: string;
   height?: string;
@@ -39,10 +53,10 @@ export interface QwilApiProps {
 }
 
 export type QwilApiEvents =
+  | 'path-change'
   | 'auth-expired'
   | 'app-error'
   | 'click-on-contact'
-  | 'chat-list-back'
   | 'download-request'
   | 'meeting-join';
 


### PR DESCRIPTION
# Config Options

**Added**
* `canStartChat` 
* `startChatTitle`
* `startChatSubmitButtonText`
* `startChatTitleLabel`
* `startChatMessageLabel`
* `hideTopNav`
* `topNavLabelContacts`
* `topNavLabelChats`
* `topNavHeading`
* `contactEmailClickable`
* `contactPhoneClickable`
* `showOrgNameOnContactsPage`
* `searchBackButtonLabel`
* `searchNoResultsMessage`

**Removed**
* `chatListTitle`
* `chatListLogo`
* `emitChatListBack`

# Events

**Added**
`path-change`

**Removed**
`chat-list-back`